### PR TITLE
Refactor NFO master loader and add fetcher helper

### DIFF
--- a/master_contract_fetcher.py
+++ b/master_contract_fetcher.py
@@ -1,0 +1,34 @@
+import logging
+from datetime import datetime
+
+import pandas as pd
+import requests
+
+from telegram_alerts import send_telegram_alert
+
+SCRIP_MASTER_URL = "https://margincalculator.angelbroking.com/OpenAPI_File/files/OpenAPIScripMaster.json"
+SCRIP_MASTER_PATH = "nfo_scrip_master.csv"
+
+
+def fetch_and_save_nfo_master_contract(path: str = SCRIP_MASTER_PATH) -> str:
+    """Fetch the NFO master contract and save it to ``path``.
+
+    The returned CSV contains only NFO segment records and includes a
+    ``fetch_timestamp`` column used for cache freshness checks.
+    """
+    try:
+        response = requests.get(SCRIP_MASTER_URL, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        df = pd.DataFrame(data)
+        nfo_df = df[df["exch_seg"] == "NFO"].copy()
+        nfo_df["fetch_timestamp"] = datetime.now()
+        nfo_df.to_csv(path, index=False)
+        return path
+    except Exception as exc:  # noqa: BLE001
+        logging.exception("master_contract_fetcher: failed to fetch NFO master contract: %s", exc)
+        try:
+            send_telegram_alert(f"master_contract_fetcher error: {exc}")
+        except Exception:  # noqa: BLE001
+            logging.exception("master_contract_fetcher: failed to send Telegram alert")
+        raise


### PR DESCRIPTION
## Summary
- consolidate `load_nfo_scrip_master` into single, documented function with cache refresh and error alerts
- add `master_contract_fetcher` module to download and timestamp NFO master contract

## Testing
- `python -m py_compile angel_utils.py master_contract_fetcher.py`
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'foo')*
- `pytest tests/test_live_market_readiness.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689011800d7883319cdbd80cf65b0023