### PR TITLE
fix: handle cache encoding errors

### DIFF
--- a/session_manager.py
+++ b/session_manager.py
@@ -5,6 +5,7 @@ import os
 import json
 import time
 from login_manager import AngelLoginManager
+from telegram_alerts import send_telegram_alert
 
 SESSION_CACHE_FILE = "session_cache.json"
 
@@ -27,8 +28,10 @@ class SessionManager:
             with open(SESSION_CACHE_FILE, "w") as f:
                 json.dump(cache_data, f)
             os.chmod(SESSION_CACHE_FILE, 0o600)  # Secure permissions
-        except (IOError, json.JSONEncodeError) as e:
-            print(f"Error saving cache: {e}")
+        except (IOError, TypeError, OverflowError) as e:
+            msg = f"[SessionManager] Error saving cache: {e}"
+            print(msg)
+            send_telegram_alert(msg)
 
     def _load_from_cache(self):
         if not os.path.exists(SESSION_CACHE_FILE):
@@ -38,11 +41,14 @@ class SessionManager:
                 cache_data = json.load(f)
             if "session_data" in cache_data and "last_login_time" in cache_data:
                 return cache_data
-            else:
-                print("Invalid cache format")
-                return None
+            msg = "[SessionManager] Invalid cache format"
+            print(msg)
+            send_telegram_alert(msg)
+            return None
         except (IOError, json.JSONDecodeError) as e:
-            print(f"Error loading cache: {e}")
+            msg = f"[SessionManager] Error loading cache: {e}"
+            print(msg)
+            send_telegram_alert(msg)
             return None
 
     def is_expired(self):


### PR DESCRIPTION
## Summary
- replace deprecated json.JSONEncodeError with TypeError and OverflowError in session cache
- add module-tagged logging and Telegram alerts for cache save/load failures

## Testing
- `pytest -q` *(fails: detect_trend missing args; logzero, SmartApi modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890113de354833191c93313b2cadccb