### PR TITLE
Enhance scrip master download resilience

### DIFF
--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import sys
+
+import pytest
+from requests.exceptions import RequestException
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import token_manager
+
+
+class DummyResponse:
+    status_code = 200
+
+    def json(self):
+        return {"data": 1}
+
+    def raise_for_status(self):
+        pass
+
+
+def test_download_scrip_master_success(tmp_path, monkeypatch):
+    temp_file = tmp_path / "scrip.json"
+    monkeypatch.setattr(token_manager, "LOCAL_SCRIP_FILE", str(temp_file))
+    monkeypatch.setattr(token_manager.requests, "get", lambda *a, **k: DummyResponse())
+    messages = []
+    monkeypatch.setattr(token_manager, "send_telegram_alert", lambda m: messages.append(m))
+
+    assert token_manager.download_scrip_master()
+    assert temp_file.exists()
+    assert messages == []
+
+
+def test_download_scrip_master_failure(tmp_path, monkeypatch):
+    temp_file = tmp_path / "scrip.json"
+    monkeypatch.setattr(token_manager, "LOCAL_SCRIP_FILE", str(temp_file))
+
+    def fake_get(*args, **kwargs):
+        raise RequestException("offline")
+
+    monkeypatch.setattr(token_manager.requests, "get", fake_get)
+    messages = []
+    monkeypatch.setattr(token_manager, "send_telegram_alert", lambda m: messages.append(m))
+
+    assert not token_manager.download_scrip_master(retries=1)
+    assert messages and "Failed to download scrip master" in messages[0]
+    assert not temp_file.exists()

--- a/token_manager.py
+++ b/token_manager.py
@@ -1,29 +1,58 @@
 # modules/token_finder.py
 # Use this for searching option tokens dynamically from scrip master
 
-import requests
 import json
+import logging
 import os
+
 import pandas as pd
+import requests
+from requests.exceptions import RequestException
+
+from telegram_alerts import send_telegram_alert
 
 SCRIP_MASTER_URL = "https://margincalculator.angelbroking.com/OpenAPI_File/files/OpenAPIScripMaster.json"
 LOCAL_SCRIP_FILE = "scrip_master.json"
 
-def download_scrip_master():
-    if not os.path.exists(LOCAL_SCRIP_FILE):
-        response = requests.get(SCRIP_MASTER_URL)
-        if response.status_code == 200:
-            with open(LOCAL_SCRIP_FILE, 'w') as f:
+logger = logging.getLogger(__name__)
+
+
+def download_scrip_master(retries: int = 3) -> bool:
+    """Download the scrip master with retry and alerting."""
+    if os.path.exists(LOCAL_SCRIP_FILE):
+        logger.info("token_manager: Using existing scrip master.")
+        return True
+
+    for attempt in range(1, retries + 1):
+        try:
+            response = requests.get(SCRIP_MASTER_URL, timeout=10)
+            response.raise_for_status()
+            with open(LOCAL_SCRIP_FILE, "w") as f:
                 json.dump(response.json(), f)
-            print("✅ Scrip master downloaded.")
-        else:
-            raise Exception(f"❌ Failed to download: {response.status_code}")
-    else:
-        print("📁 Using existing scrip master.")
+            logger.info("token_manager: Scrip master downloaded.")
+            return True
+        except RequestException as e:
+            logger.warning(
+                "token_manager: download attempt %s failed: %s", attempt, e
+            )
+        except OSError as e:
+            logger.error("token_manager: Failed to write scrip master: %s", e)
+            send_telegram_alert(
+                f"token_manager: file save failed - {e}"
+            )
+            return False
+
+    msg = (
+        f"token_manager: Failed to download scrip master after {retries} attempts."
+    )
+    logger.error(msg)
+    send_telegram_alert(msg)
+    return False
 
 def load_scrip_data():
-    download_scrip_master()
-    with open(LOCAL_SCRIP_FILE, 'r') as f:
+    if not download_scrip_master() and not os.path.exists(LOCAL_SCRIP_FILE):
+        raise FileNotFoundError("token_manager: scrip master unavailable.")
+    with open(LOCAL_SCRIP_FILE, "r") as f:
         return pd.DataFrame(json.load(f))
 
 def get_token_by_symbol(symbol, exchange='NFO', instrumenttype='OPTIDX', expiry=None, optiontype=None, strike=None):


### PR DESCRIPTION
## Summary
- add retry, logging and Telegram alerts for scrip master downloads
- unit test token manager download flow

## Testing
- `pytest tests/test_token_manager.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'logzero'; ModuleNotFoundError: No module named 'SmartApi'; TypeError: detect_trend() missing 2 required positional arguments: 'ce_strike' and 'pe_strike')*

------
https://chatgpt.com/codex/tasks/task_e_68901143fd3483319765fb86ae9b9306