### PR TITLE
Add self audit script and tests

### DIFF
--- a/self_audit.py
+++ b/self_audit.py
@@ -1,0 +1,87 @@
+import os
+import ast
+import argparse
+import logging
+from typing import Dict, List
+
+from telegram_alerts import send_telegram_alert
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def _attempt_import(module_name: str, file_path: str, missing: List[Dict], errors: List[Dict]):
+    """Attempt to import a module and log failures."""
+    try:
+        __import__(module_name)
+    except ImportError:
+        missing.append({"module": module_name, "file": file_path})
+        msg = f"Missing module {module_name} in {file_path}"
+        logger.error(msg)
+        send_telegram_alert(msg)
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        msg = f"Error importing {module_name} in {file_path}: {exc}"
+        logger.error(msg)
+        send_telegram_alert(msg)
+        errors.append({"module": module_name, "file": file_path, "error": str(exc)})
+
+
+def scan_repository(base_path: str = ".") -> Dict[str, List[Dict]]:
+    """Scan repository for missing modules and performance issues."""
+    missing_modules: List[Dict] = []
+    performance_issues: List[str] = []
+    errors: List[Dict] = []
+
+    for root, _, files in os.walk(base_path):
+        for filename in files:
+            if not filename.endswith(".py"):
+                continue
+            path = os.path.join(root, filename)
+
+            try:
+                if os.path.getsize(path) > 1_000_000:  # 1MB threshold
+                    performance_issues.append(path)
+                    logger.warning("Performance issue: %s exceeds size threshold", path)
+            except Exception as exc:
+                msg = f"Error checking size for {path}: {exc}"
+                logger.error(msg)
+                send_telegram_alert(msg)
+                errors.append({"file": path, "error": str(exc)})
+
+            try:
+                with open(path, "r", encoding="utf-8") as handle:
+                    tree = ast.parse(handle.read(), filename=path)
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Import):
+                        for alias in node.names:
+                            module_name = alias.name.split(".")[0]
+                            _attempt_import(module_name, path, missing_modules, errors)
+                    elif isinstance(node, ast.ImportFrom) and node.module:
+                        module_name = node.module.split(".")[0]
+                        _attempt_import(module_name, path, missing_modules, errors)
+            except Exception as exc:
+                msg = f"Error scanning {path}: {exc}"
+                logger.error(msg)
+                send_telegram_alert(msg)
+                errors.append({"file": path, "error": str(exc)})
+
+    return {
+        "missing_modules": missing_modules,
+        "performance_issues": performance_issues,
+        "errors": errors,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Self audit utilities.")
+    parser.add_argument("--scan", action="store_true", help="Run repository scan")
+    parser.add_argument("--path", default=".", help="Path to scan")
+    args = parser.parse_args()
+
+    if args.scan:
+        results = scan_repository(args.path)
+        print(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_self_audit.py
+++ b/tests/test_self_audit.py
@@ -1,0 +1,43 @@
+"""Tests for self_audit module."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import self_audit
+
+
+class DummyAlert:
+    """Collect messages instead of sending Telegram alerts."""
+
+    def __init__(self):
+        self.messages = []
+
+    def __call__(self, message: str):
+        self.messages.append(message)
+
+
+def test_reports_missing_module(tmp_path, monkeypatch):
+    target = tmp_path / "mod.py"
+    target.write_text("import nonexistent_module\n")
+    dummy = DummyAlert()
+    monkeypatch.setattr(self_audit, "send_telegram_alert", dummy)
+
+    result = self_audit.scan_repository(base_path=str(tmp_path))
+
+    assert any(entry["module"] == "nonexistent_module" for entry in result["missing_modules"])
+    assert dummy.messages  # alert triggered
+
+
+def test_handles_invalid_syntax(tmp_path, monkeypatch):
+    target = tmp_path / "bad.py"
+    target.write_text("def broken(:\n    pass")
+    dummy = DummyAlert()
+    monkeypatch.setattr(self_audit, "send_telegram_alert", dummy)
+
+    result = self_audit.scan_repository(base_path=str(tmp_path))
+
+    assert result["errors"]
+    assert dummy.messages  # alert triggered


### PR DESCRIPTION
## Summary
- add self_audit.py script to walk repo, flag missing imports, and send Telegram alerts
- expose CLI entry for scheduled scans
- include unit tests covering missing module detection and error handling

## Testing
- `pytest -q` *(fails: detect_trend missing args; ModuleNotFoundError for SmartApi/logzero)*
- `pip install logzero SmartApi -q` *(fails: Failed building wheel for PyCrypto)*
- `pytest tests/test_self_audit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689038397d5083319ed30256f12bb798