### PR TITLE
Add error handling and CLI to module creator

### DIFF
--- a/tests/test_module_creator.py
+++ b/tests/test_module_creator.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import module_creator
+
+
+def test_create_modules_success(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    alerts = []
+    monkeypatch.setattr(module_creator, "send_telegram_alert", lambda msg: alerts.append(msg))
+
+    module_creator.create_modules(["foo.py"])
+
+    assert os.path.exists("foo.py")
+    assert alerts == []
+
+
+def test_create_modules_write_failure(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    alerts = []
+
+    def fake_alert(message):
+        alerts.append(message)
+
+    def fail_open(*args, **kwargs):
+        raise IOError("disk full")
+
+    monkeypatch.setattr(module_creator, "send_telegram_alert", fake_alert)
+    monkeypatch.setattr("builtins.open", fail_open)
+
+    module_creator.create_modules(["bad.py"])
+
+    assert alerts and "bad.py" in alerts[0]
+    assert not os.path.exists("bad.py")


### PR DESCRIPTION
## Summary
- add robust error handling with Telegram alerts to `create_modules`
- enable CLI file creation via `--files`
- cover success and failure paths in unit tests

## Testing
- `pytest`
- `pytest tests/test_module_creator.py`


------
https://chatgpt.com/codex/tasks/task_e_6890383b221c8331aeb4d175dcfd17a7