### PR TITLE
refactor: use logger and telegram alert in order executor

### DIFF
--- a/order_executor.py
+++ b/order_executor.py
@@ -1,4 +1,12 @@
+import logging
+
+from telegram_alerts import send_telegram_alert
+
 # Executes orders using SmartAPI
+
+logger = logging.getLogger(__name__)
+
+
 def place_order(order_data, smart_api_obj):
     """
     order_data = {
@@ -16,9 +24,10 @@ def place_order(order_data, smart_api_obj):
     """
     try:
         response = smart_api_obj.placeOrder(order_data)
-        print("✅ Order placed:", response)
+        logger.info("order_executor: Order placed: %s", response)
         return response
     except Exception as e:
-        print("❌ Order failed:", e)
-        return None
+        logger.exception("order_executor: Order failed: %s", e)
+        send_telegram_alert(f"OrderExecutor error: {e}")
+        raise
 


### PR DESCRIPTION
## Summary
- add logging and telegram alert to order executor
- replace prints with logger methods and propagate errors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'logzero'; ModuleNotFoundError: No module named 'SmartApi'; detect_trend() missing 2 required positional arguments: 'ce_strike' and 'pe_strike')*

------
https://chatgpt.com/codex/tasks/task_e_68903952ef54833195ea0bb2cf629cff