### PR TITLE
Improve module creation error handling

### DIFF
--- a/module_creator.py
+++ b/module_creator.py
@@ -1,5 +1,8 @@
 import os
 
+from telegram_alerts import send_telegram_alert
+from utils.logger import default_logger as logger
+
 TEMPLATES = {
     "session_manager.py": '''# Handles session re-use and token management
 import json
@@ -25,19 +28,66 @@ def check_position_limits():
 '''
 }
 
+
 def create_modules(missing_files):
+    """Create missing module files and directories.
+
+    Args:
+        missing_files (list[str]): List of file paths to create.
+
+    Returns:
+        dict: Summary of created files and failures.
+    """
+    summary = {"created": [], "failed": []}
+
     for file in missing_files:
         dir_name = os.path.dirname(file)
         if dir_name and not os.path.exists(dir_name):
-            os.makedirs(dir_name)
-        
-        with open(file, "w") as f:
-            f.write(TEMPLATES.get(file, "# Empty Module\n"))
-        print(f"🛠 Created: {file}")
+            try:
+                os.makedirs(dir_name)
+            except OSError as exc:
+                msg = (
+                    f"module_creator: failed to create directory '{dir_name}' for"
+                    f" '{file}': {exc}"
+                )
+                logger.error(msg)
+                try:
+                    send_telegram_alert(f"🛑 {msg}")
+                except Exception:
+                    logger.exception(
+                        "module_creator: failed to send Telegram alert"
+                    )
+                summary["failed"].append(
+                    {"file": file, "error": str(exc), "stage": "directory"}
+                )
+                continue
+
+        try:
+            with open(file, "w", encoding="utf-8") as f:
+                f.write(TEMPLATES.get(file, "# Empty Module\n"))
+            logger.info(f"module_creator: created module '{file}'")
+            summary["created"].append(file)
+        except OSError as exc:
+            msg = f"module_creator: failed to create file '{file}': {exc}"
+            logger.error(msg)
+            try:
+                send_telegram_alert(f"🛑 {msg}")
+            except Exception:
+                logger.exception(
+                    "module_creator: failed to send Telegram alert"
+                )
+            summary["failed"].append(
+                {"file": file, "error": str(exc), "stage": "file"}
+            )
+
+    return summary
+
 
 if __name__ == "__main__":
     from autocode_checker import check_modules
+
     missing = check_modules()
     if missing:
-        create_modules(missing)
+        result = create_modules(missing)
+        print(result)
 

--- a/tests/test_module_creator.py
+++ b/tests/test_module_creator.py
@@ -1,0 +1,53 @@
+import builtins
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import module_creator
+
+
+def test_create_modules_success(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(module_creator, "send_telegram_alert", lambda msg: calls.append(msg))
+    target_file = tmp_path / "subdir" / "test_mod.py"
+    summary = module_creator.create_modules([str(target_file)])
+    assert target_file.exists()
+    assert summary["created"] == [str(target_file)]
+    assert summary["failed"] == []
+    assert not calls
+
+
+def test_create_modules_dir_failure(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(module_creator, "send_telegram_alert", lambda msg: calls.append(msg))
+
+    def fake_makedirs(path):
+        raise OSError("dir error")
+
+    monkeypatch.setattr(os, "makedirs", fake_makedirs)
+    target_file = tmp_path / "subdir" / "test_mod.py"
+    summary = module_creator.create_modules([str(target_file)])
+    assert not target_file.exists()
+    assert summary["created"] == []
+    assert summary["failed"][0]["file"] == str(target_file)
+    assert summary["failed"][0]["stage"] == "directory"
+    assert calls
+
+
+def test_create_modules_file_failure(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(module_creator, "send_telegram_alert", lambda msg: calls.append(msg))
+
+    def fake_open(*args, **kwargs):
+        raise OSError("write error")
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    target_file = tmp_path / "test_mod.py"
+    summary = module_creator.create_modules([str(target_file)])
+    assert not target_file.exists()
+    assert summary["created"] == []
+    assert summary["failed"][0]["file"] == str(target_file)
+    assert summary["failed"][0]["stage"] == "file"
+    assert calls


### PR DESCRIPTION
## Summary
- wrap `create_modules` operations with try/except
- log errors and send Telegram alerts on failure
- report created and failed modules
- add regression tests for module creation workflow

## Testing
- `pytest tests/test_module_creator.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'logzero')*


------
https://chatgpt.com/codex/tasks/task_e_68903894533083319b7c23bccb64474b