### PR TITLE
refactor: delegate strategy config to pages

### DIFF
--- a/strategy_config.py
+++ b/strategy_config.py
@@ -1,32 +1,22 @@
-import streamlit as st
+"""Thin wrapper to expose the Streamlit strategy configuration page.
 
-st.title("✅ strategy_config loaded")
+This wrapper exists to maintain backward compatibility. It delegates to
+``pages.strategy_config.show_strategy_config`` and reports any runtime errors
+through Telegram alerts.
+"""
 
-def show_strategy_config():
-    st.write("✅ App started")
+from pages.strategy_config import show_strategy_config
+from telegram_alerts import send_telegram_alert
 
+
+def main() -> None:
+    """Run the strategy configuration page with basic error handling."""
     try:
-        from config.settings import Settings
-        st.success("✅ Settings imported")
-    except Exception as e:
-        st.error(f"❌ Failed to import Settings: {e}")
+        show_strategy_config()
+    except Exception as exc:  # noqa: BLE001
+        send_telegram_alert(f"[strategy_config] {exc}")
+        raise
 
 
-
-# pages/strategy_config.py
-
-import sys
-from pathlib import Path
-
-# Append project root to sys.path so top‑level packages resolve correctly
-CURRENT_DIR = Path(__file__).resolve()
-PROJECT_ROOT = CURRENT_DIR.parent.parent  # parent of the `pages` folder
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.append(str(PROJECT_ROOT))
-
-import json
-import pandas as pd
-# …the rest of your imports…
-from strategies.breakout_strategy import BreakoutStrategy
-from strategies.oi_analysis import OIAnalysis
-from config.settings import Settings
+if __name__ == "__main__":
+    main()

--- a/tests/test_strategy_config_wrapper.py
+++ b/tests/test_strategy_config_wrapper.py
@@ -1,0 +1,9 @@
+"""Tests for the strategy_config thin wrapper."""
+
+import importlib
+
+
+def test_wrapper_exposes_page_function():
+    wrapper = importlib.import_module("strategy_config")
+    page = importlib.import_module("pages.strategy_config")
+    assert wrapper.show_strategy_config is page.show_strategy_config


### PR DESCRIPTION
## Summary
- remove legacy `strategy_config` implementation in project root
- add thin wrapper that delegates to `pages.strategy_config.show_strategy_config`
- add test ensuring wrapper exposes page function

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'logzero'; ModuleNotFoundError: No module named 'SmartApi'; ModuleNotFoundError: No module named 'dotenv'; ModuleNotFoundError: No module named 'pyotp'; TypeError: detect_trend() missing 2 required positional arguments)*

------
https://chatgpt.com/codex/tasks/task_e_689161eee1148331a5fec611a79ab30f