### PR TITLE
Add self-learning log viewer page

### DIFF
--- a/pages/self_learning_viewer.py
+++ b/pages/self_learning_viewer.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(MODULE)
 st.set_page_config(page_title="Self-Learning Viewer", layout="wide")
 
 
-def load_evolve_data(path: str = "evolve_log.json") -> Optional[Any]:
+def load_evolve_data(path: str = "evolve_log.json") -> Optional[dict[str, Any] | list[dict[str, Any]]]:
     """Load evolution log data from JSON file."""
     try:
         with open(path, "r", encoding="utf-8") as f:

--- a/pages/self_learning_viewer.py
+++ b/pages/self_learning_viewer.py
@@ -20,6 +20,12 @@ def load_evolve_data(path: str = "evolve_log.json") -> Optional[dict[str, Any] |
     except FileNotFoundError:
         logger.error(f"{MODULE}: {path} not found")
         send_telegram_alert(f"{MODULE}: {path} not found")
+    except PermissionError as exc:
+        logger.error(f"{MODULE}: Permission denied for {path}: {exc}")
+        send_telegram_alert(f"{MODULE}: Permission denied for {path}: {exc}")
+    except json.JSONDecodeError as exc:
+        logger.error(f"{MODULE}: Failed to decode JSON in {path}: {exc}")
+        send_telegram_alert(f"{MODULE}: Failed to decode JSON in {path}: {exc}")
     except Exception as exc:  # pylint: disable=broad-except
         logger.exception(f"{MODULE}: Failed to load {path}: {exc}")
         send_telegram_alert(f"{MODULE}: Failed to load {path}: {exc}")

--- a/pages/self_learning_viewer.py
+++ b/pages/self_learning_viewer.py
@@ -1,0 +1,49 @@
+import json
+import logging
+from typing import Any, Optional
+
+import streamlit as st
+
+from telegram_alerts import send_telegram_alert
+
+MODULE = "self_learning_viewer"
+logger = logging.getLogger(MODULE)
+
+st.set_page_config(page_title="Self-Learning Viewer", layout="wide")
+
+
+def load_evolve_data(path: str = "evolve_log.json") -> Optional[Any]:
+    """Load evolution log data from JSON file."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        logger.error(f"{MODULE}: {path} not found")
+        send_telegram_alert(f"{MODULE}: {path} not found")
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception(f"{MODULE}: Failed to load {path}: {exc}")
+        send_telegram_alert(f"{MODULE}: Failed to load {path}: {exc}")
+    return None
+
+
+def main() -> None:
+    """Render the Self-Learning Viewer page."""
+    st.title("🤖 Self-Learning Viewer")
+    try:
+        data = load_evolve_data()
+        if data is not None:
+            st.subheader("Evolution Summary")
+            if isinstance(data, list):
+                st.dataframe(data)
+            else:
+                st.json(data)
+        else:
+            st.warning("No evolution data available.")
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception(f"{MODULE}: Display error: {exc}")
+        send_telegram_alert(f"{MODULE}: Display error - {exc}")
+        st.error("Failed to display evolution data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/self_learning_viewer.py
+++ b/pages/self_learning_viewer.py
@@ -45,7 +45,7 @@ def main() -> None:
                 st.json(data)
         else:
             st.warning("No evolution data available.")
-    except Exception as exc:  # pylint: disable=broad-except
+    except (ValueError, TypeError, StreamlitAPIException) as exc:
         logger.exception(f"{MODULE}: Display error: {exc}")
         send_telegram_alert(f"{MODULE}: Display error - {exc}")
         st.error("Failed to display evolution data.")

--- a/tests/test_self_learning_viewer.py
+++ b/tests/test_self_learning_viewer.py
@@ -1,0 +1,29 @@
+import json
+
+from pages import self_learning_viewer as slv
+
+
+def test_load_evolve_data_success(tmp_path, monkeypatch):
+    data = {"step": 1, "status": "ok"}
+    file_path = tmp_path / "evolve_log.json"
+    file_path.write_text(json.dumps(data))
+
+    alerts = []
+    monkeypatch.setattr(slv, "send_telegram_alert", lambda msg: alerts.append(msg))
+
+    result = slv.load_evolve_data(str(file_path))
+
+    assert result == data
+    assert alerts == []
+
+
+def test_load_evolve_data_missing(monkeypatch, tmp_path):
+    file_path = tmp_path / "missing.json"
+
+    alerts = []
+    monkeypatch.setattr(slv, "send_telegram_alert", lambda msg: alerts.append(msg))
+
+    result = slv.load_evolve_data(str(file_path))
+
+    assert result is None
+    assert len(alerts) == 1


### PR DESCRIPTION
## Summary
- add new Streamlit page to view self-learning evolution log with error handling and Telegram alerts
- implement tests for log loading success and missing file scenarios

## Testing
- `pytest -q` *(fails: missing environment variables and other pre-existing errors)*
- `PYTHONPATH=. pytest tests/test_self_learning_viewer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689162174f4483319eab2d11cc7544d2